### PR TITLE
Add a way to hard reject requests from load manager

### DIFF
--- a/load_manager/load_manager.go
+++ b/load_manager/load_manager.go
@@ -93,11 +93,11 @@ func (l *LoadManager) GetResource(
 		return resource
 	}
 
-        // If a rule violated has a capacity of 0 then we simply reject the request
-        // without going through the suspicious queue.
-        if resource.Suspicious() && resource.TrackingInfo.Violated.Capacity == hardReject {
-                return resource
-        }
+	// If a rule violated has a capacity of 0 then we simply reject the request
+	// without going through the suspicious queue.
+	if resource.Suspicious() && resource.TrackingInfo.Violated.Capacity == hardReject {
+		return resource
+	}
 
 	// Slow path. Scorecard violation. Maybe get a suspicious ticket.
 	ticket := l.suspiciousQueue.AdmitOne()

--- a/load_manager/load_manager.go
+++ b/load_manager/load_manager.go
@@ -26,6 +26,8 @@ import (
 
 const suspiciousQueueName = "suspicious"
 
+const hardReject = uint(0)
+
 // A LoadManager uses AdmissionControl and Scorecard to do traffic shaping.
 //
 // Specifically, it sets the following limits:
@@ -90,6 +92,12 @@ func (l *LoadManager) GetResource(
 	if resource.QueueInfo.Ticket == nil {
 		return resource
 	}
+
+        // If a rule violated has a capacity of 0 then we simply reject the request
+        // without going through the suspicious queue.
+        if resource.Suspicious() && resource.TrackingInfo.Violated.Capacity == hardReject {
+                return resource
+        }
 
 	// Slow path. Scorecard violation. Maybe get a suspicious ticket.
 	ticket := l.suspiciousQueue.AdmitOne()

--- a/load_manager/load_manager_test.go
+++ b/load_manager/load_manager_test.go
@@ -327,25 +327,25 @@ func TestLoadManagerRefcounting(t *testing.T) {
 }
 
 func TestHardReject(t *testing.T) {
-        ctx := context.Background()
+	ctx := context.Background()
 
-        queueNames, queues := makeQueues(1, 1)
-        tag := scorecard.Tag("prefix:val")
+	queueNames, queues := makeQueues(1, 1)
+	tag := scorecard.Tag("prefix:val")
 
-        loadManager := NewLoadManager(
-                queues,
-                ac.NewAdmissionController(1),
-                scorecard.NewDynamicScorecard(
-                        []scorecard.Rule{{Pattern: string(tag), Capacity: hardReject}}),
-                scorecard.NewDynamicScorecard(scorecard.NoRules()),
-                scorecard.NoTags(),
-        )
+	loadManager := NewLoadManager(
+		queues,
+		ac.NewAdmissionController(1),
+		scorecard.NewDynamicScorecard(
+			[]scorecard.Rule{{Pattern: string(tag), Capacity: hardReject}}),
+		scorecard.NewDynamicScorecard(scorecard.NoRules()),
+		scorecard.NoTags(),
+	)
 
-        resource := loadManager.GetResource(ctx, queueNames[0], []scorecard.Tag{tag})
-        // We should not acquire any admission control tickets
-        require.False(t, resource.Acquired())
-        // Request should be marked suspicious
-        require.True(t, resource.Suspicious())
+	resource := loadManager.GetResource(ctx, queueNames[0], []scorecard.Tag{tag})
+	// We should not acquire any admission control tickets
+	require.False(t, resource.Acquired())
+	// Request should be marked suspicious
+	require.True(t, resource.Suspicious())
 }
 
 func makeQueues(num int, capacity uint) ([]string, map[string]ac.AdmissionController) {

--- a/load_manager/load_manager_test.go
+++ b/load_manager/load_manager_test.go
@@ -326,6 +326,28 @@ func TestLoadManagerRefcounting(t *testing.T) {
 	}
 }
 
+func TestHardReject(t *testing.T) {
+        ctx := context.Background()
+
+        queueNames, queues := makeQueues(1, 1)
+        tag := scorecard.Tag("prefix:val")
+
+        loadManager := NewLoadManager(
+                queues,
+                ac.NewAdmissionController(1),
+                scorecard.NewDynamicScorecard(
+                        []scorecard.Rule{{Pattern: string(tag), Capacity: hardReject}}),
+                scorecard.NewDynamicScorecard(scorecard.NoRules()),
+                scorecard.NoTags(),
+        )
+
+        resource := loadManager.GetResource(ctx, queueNames[0], []scorecard.Tag{tag})
+        // We should not acquire any admission control tickets
+        require.False(t, resource.Acquired())
+        // Request should be marked suspicious
+        require.True(t, resource.Suspicious())
+}
+
 func makeQueues(num int, capacity uint) ([]string, map[string]ac.AdmissionController) {
 	queueNames := make([]string, num)
 	for idx := range queueNames {


### PR DESCRIPTION
Sometimes even a limit of 1 active request can be enough to take the databases down. In such situations its useful to be able to simply hard reject the requests