### PR TITLE
Use custom match function instead of generic glob match for better pe…

### DIFF
--- a/scorecard/rule_parsing.go
+++ b/scorecard/rule_parsing.go
@@ -61,10 +61,7 @@ func FastMatch(t Tag, p string) bool {
 		// There is a wild card at the end of the pattern string.
 		// If the pattern is a prefix of the tag passed in
 		// then return true because the wildcard matches everything.
-		if strings.HasPrefix(ts, p[:pLen-1]) {
-			return true
-		}
-		return false
+		return strings.HasPrefix(ts, p[:pLen-1])
 	}
 	return ts == p
 }

--- a/scorecard/scorecard_bench_test.go
+++ b/scorecard/scorecard_bench_test.go
@@ -301,5 +301,145 @@ func BenchmarkScorecardGenerate(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		sc.TrackRequest(tags)
 	}
+}
 
+var benchmarkRules = []Rule{
+	{"traffic:batch_traffic;source:blackbird_worker_prod_high_memory_sjc-blackbird_worker_bin", 5},
+	{"source:segmentation*", 30},
+	{"traffic:batch_traffic;source:filesystem.fs_job_worker_fs_job_worker-backfill_bin", 10},
+	{"traffic:batch_traffic;tclass:master;client_id:*", 60},
+	{"traffic:batch_traffic;tclass:slave;source:owner_team_data_infra-mapper.py", 5},
+	{"traffic:batch_traffic;tclass:slave;client_id:*", 5},
+	{"traffic:live_traffic;source:metaserver*", 400},
+	{"traffic:live_traffic;source:*", 50},
+	{"op:gid_create_txn", 100},
+	{"op:gid_create_txn;colo:*", 1},
+	{"traffic:batch_traffic;tclass:master;source:*", 30},
+	{"traffic:batch_traffic;tclass:slave;source:*", 60},
+	{"op:read_list;source:cape*", 20},
+	{"op:scan", 10},
+	{"source:*;op:scan", 2}}
+var requests = [][]Tag{
+	{"source:cape_yss_workers_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda_iad-async_task_worker_wrapper.py", "client_id:meta", "op:insert_revision", "op:read_gid2", "traffic:live_traffic"},
+	{"source:fsverifier_fsverifier_worker_prod-fsverifier_worker_bin", "client_id:audit_log", "op:read_revision", "op:txn", "traffic:live_traffic"},
+	{"source:cape_dispatcher_yss_edgestore_canary-cape_dispatcher_bin", "client_id:cape_dispatcher", "op:gid_create_read_id", "op:read_ep", "traffic:batch_traffic"},
+	{"source:owner_shared_spaces-count_shmodels_banned_under_rl_migration.py", "client_id:argus", "op:read_xtxn_conflict", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:filejournal_sjc.prod-fj_server_1.12_bin", "client_id:taskrunner_sharing_platform", "op:txn", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_canary_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda-async_task_worker_wrapper.py", "client_id:blackbird_prod_common", "op:txn", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:owner_messaging_team-delphi_store_consumer_bin", "client_id:megaphone_bluemail_kafka_consumer", "op:read_gid2", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:metaserver_courier_live_site_control-main.py", "client_id:megaphone_bluemail_kafka_consumer", "op:insert_revision", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:sync_frontend_sjc.canary-sync_frontend_server_bin", "client_id:atf_hsc", "op:gid_create_read_id", "op:read_gid2", "traffic:live_traffic"},
+	{"source:audit_log.atf_async_file_events_logging_workers_download_file_event_lambda-atf_controller_bin", "client_id:blackbird_prod_common", "op:read_revision", "op:insert_revision", "traffic:live_traffic"},
+	{"source:metaserver_client-paster", "client_id:cape_dispatcher", "op:read_xtxn_conflict", "op:insert_revision", "traffic:live_traffic"},
+	{"source:cape_yss_workers_canary_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda-async_task_worker_wrapper.py", "client_id:filesystem", "op:gid_create_read_id", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:owner_shared_spaces-count_shmodels_banned_under_rl_migration.py", "client_id:taskrunner_team_lifecycle", "op:read_xtxn_conflict", "op:read_revision", "traffic:batch_traffic"},
+	{"source:metaserver_courier_live_site_control-main.py", "client_id:atf_controller", "op:gid_create_read_id", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:atf.frontend_yss_frontend_prod-atf_frontend_bin", "client_id:taskrunner_sharing_platform", "op:gid_create_read_id", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:audit_log.atf_async_file_events_logging_workers_download_file_event_lambda-atf_controller_bin", "client_id:blackbird_prod_alki-qa-streamer", "op:insert_revision", "op:read_revision", "traffic:live_traffic"},
+	{"source:fs_move_worker_sjc.prod-fs_move_worker_bin", "client_id:argus", "op:read_ep", "op:read_xtxn_conflict", "traffic:live_traffic"},
+	{"source:cape_yss_workers_RemoveMemberOnFileObjMoveTopology_RemoveMemberOnFileObjMoveLambda-remove_member_on_file_obj_move.py", "client_id:taskrunner_prod", "op:read_gid2", "op:read_gid2", "traffic:live_traffic"},
+	{"source:filejournal_sjc.prod-fj_server_1.12_bin", "client_id:atf_hsc", "op:gid_create_read_id", "op:read_gid2", "traffic:live_traffic"},
+	{"source:metaserver_courier_live_site-main.py", "client_id:segmentation", "op:read_gid2", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:owner_filesystem_team-namespace_member_backedge_consistency_checker.py", "client_id:sync_frontend", "op:read_gid2", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:filejournal_sjc.prod-fj_server_1.12_bin", "client_id:megaphone_journey_builder", "op:read_xtxn_conflict", "op:prepare_xtxn", "traffic:live_traffic"},
+	{"source:megaphone_megaphone_rpc_service_prod-megaphone_rpc_service.py", "client_id:megaphone_journey_builder", "op:insert_revision", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:metaserver_courier_live_site-main.py", "client_id:team_lifecycle", "op:read_ep", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:metaserver_client_control-paster", "client_id:cloud_docs", "op:read_xtxn_conflict", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:fsverifier_fsverifier_worker_prod-fsverifier_worker_bin", "client_id:iam", "op:prepare_xtxn", "op:read_gid2", "traffic:live_traffic"},
+	{"source:audit_log.atf_async_file_events_logging_workers_download_file_event_lambda-atf_controller_bin", "client_id:megaphone_bluemail_kafka_consumer", "op:read_xtxn_conflict", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_canary_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda-async_task_worker_wrapper.py", "client_id:atf_controller", "op:gid_create_read_id", "op:txn", "traffic:live_traffic"},
+	{"source:fsverifier_fsverifier_worker_prod-fsverifier_worker_bin", "client_id:filesystem", "op:read_revision", "op:read_revision", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda_iad-async_task_worker_wrapper.py", "client_id:cape_workers", "op:gid_create_read_id", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:owner_messaging_team-delphi_store_consumer_bin", "client_id:audit_log", "op:read_revision", "op:read_revision", "traffic:batch_traffic"},
+	{"source:atf.store_consumer_yss_store_consumer_prod-atf_store_consumer_bin", "client_id:sprinkle", "op:gid_create_read_id", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:atf.store_consumer_yss_store_consumer_prod-atf_store_consumer_bin", "client_id:taskrunner_sharing_platform", "op:gid_create_read_id", "op:gid_create_read_id", "traffic:live_traffic"},
+	{"source:audit_log.atf_async_file_events_logging_workers_download_file_event_lambda-atf_controller_bin", "client_id:meta", "op:txn", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:argus", "op:insert_revision", "op:txn", "traffic:batch_traffic"},
+	{"source:atf.store_consumer_yss_store_consumer_prod-atf_store_consumer_bin", "client_id:atf_store_consumer", "op:insert_revision", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_PhotoAndVideoCollectionsRefreshTopology_PhotoVideoCollectionsRefreshLambda-pv_collections_refresh.py", "client_id:argus", "op:read_revision", "op:insert_revision", "traffic:live_traffic"},
+	{"source:audit_log.atf_async_file_events_logging_workers_download_file_event_lambda-atf_controller_bin", "client_id:dropbox", "op:txn", "op:insert_revision", "traffic:live_traffic"},
+	{"source:blackbird_worker_prod_restorations_sjc-blackbird_worker_bin", "client_id:filesystem", "op:read_xtxn_conflict", "op:txn", "traffic:batch_traffic"},
+	{"source:sync_frontend_sjc.prod-sync_frontend_server_bin", "client_id:filesystem", "op:gid_create_read_id", "op:txn", "traffic:batch_traffic"},
+	{"source:metaserver_client-paster", "client_id:segmentation", "op:insert_revision", "op:read_ep", "traffic:batch_traffic"},
+	{"source:filejournal_sjc.prod-fj_server_1.12_bin", "client_id:iam", "op:gid_create_read_id", "op:insert_revision", "traffic:live_traffic"},
+	{"source:sync_frontend_sjc.prod-sync_frontend_server_bin", "client_id:taskrunner_team_lifecycle", "op:insert_revision", "op:txn", "traffic:batch_traffic"},
+	{"source:owner_filesystem_team-namespace_member_backedge_consistency_checker.py", "client_id:blackbird_prod_common", "op:insert_revision", "op:read_xtxn_conflict", "traffic:live_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:megaphone_journey_builder", "op:read_xtxn_conflict", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:megaphone_megaphone_rpc_service_prod-megaphone_rpc_service.py", "client_id:cloud_docs", "op:read_revision", "op:gid_create_read_id", "traffic:live_traffic"},
+	{"source:cape_yss_workers_PhotoAndVideoCollectionsRefreshTopology_PhotoVideoCollectionsRefreshLambda-pv_collections_refresh.py", "client_id:blackbird_prod_restorations", "op:gid_create_read_id", "op:read_xtxn_conflict", "traffic:live_traffic"},
+	{"source:owner_messaging_team-delphi_store_consumer_bin", "client_id:audit_log", "op:insert_revision", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:megaphone_megaphone_rpc_service_prod-megaphone_rpc_service.py", "client_id:taskrunner_team_lifecycle", "op:read_xtxn_conflict", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:owner_shared_spaces-count_shmodels_banned_under_rl_migration.py", "client_id:taskrunner_prod", "op:read_xtxn_conflict", "op:read_xtxn_conflict", "traffic:live_traffic"},
+	{"source:sync_frontend_sjc.prod-sync_frontend_server_bin", "client_id:atf_hsc", "op:read_xtxn_conflict", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:filejournal_sjc.prod-fj_server_1.12_bin", "client_id:argus", "op:prepare_xtxn", "op:read_revision", "traffic:live_traffic"},
+	{"source:metaserver_client_control-paster", "client_id:atf_hsc", "op:read_gid2", "op:read_gid2", "traffic:live_traffic"},
+	{"source:gatekeeper_sjc.prod-gatekeeper_svc_bin", "client_id:blackbird_prod_high-memory", "op:read_xtxn_conflict", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:cape_dispatcher_yss_edgestore_prod-cape_dispatcher_bin", "client_id:blackbird_prod_alki-qa-streamer", "op:txn", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:megaphone_bluemail_kafka_consumer", "op:read_xtxn_conflict", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:blackbird_prod_common", "op:prepare_xtxn", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_PhotoAndVideoCollectionsRefreshTopology_PhotoVideoCollectionsRefreshLambda-pv_collections_refresh.py", "client_id:taskrunner_prod", "op:gid_create_read_id", "op:insert_revision", "traffic:live_traffic"},
+	{"source:cape_yss_workers_canary_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda-async_task_worker_wrapper.py", "client_id:dropbox", "op:read_ep", "op:insert_revision", "traffic:live_traffic"},
+	{"source:atf.store_consumer_yss_store_consumer_prod-atf_store_consumer_bin", "client_id:atf_controller", "op:prepare_xtxn", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:cape_dispatcher_yss_edgestore_canary-cape_dispatcher_bin", "client_id:dropbox", "op:txn", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:metaserver_courier_live_site-main.py", "client_id:atf_hsc", "op:gid_create_read_id", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:atf_test_cluster_workers_atf_test_lambda-atf_controller_bin", "client_id:argus", "op:gid_create_read_id", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:gatekeeper_sjc.prod-gatekeeper_svc_bin", "client_id:megaphone_bluemail_kafka_consumer", "op:read_revision", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_canary_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda-async_task_worker_wrapper.py", "client_id:search_indexer", "op:read_gid2", "op:gid_create_read_id", "traffic:live_traffic"},
+	{"source:sync_frontend_sjc.prod-sync_frontend_server_bin", "client_id:taskrunner_team_lifecycle", "op:prepare_xtxn", "op:read_xtxn_conflict", "traffic:live_traffic"},
+	{"source:gatekeeper_sjc.prod-gatekeeper_svc_bin", "client_id:atf_store_consumer", "op:read_ep", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_RemoveMemberOnFileObjMoveTopology_RemoveMemberOnFileObjMoveLambda-remove_member_on_file_obj_move.py", "client_id:megaphone_journey_builder", "op:prepare_xtxn", "op:read_ep", "traffic:batch_traffic"},
+	{"source:owner_messaging_team-delphi_store_consumer_bin", "client_id:taskrunner_team_lifecycle", "op:gid_create_read_id", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:atf_test_cluster_workers_atf_test_lambda-atf_controller_bin", "client_id:megaphone_journey_builder", "op:txn", "op:txn", "traffic:live_traffic"},
+	{"source:fs_move_worker_sjc.prod-fs_move_worker_bin", "client_id:blackbird_prod_high-memory", "op:read_xtxn_conflict", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:fs_move_worker_sjc.prod-fs_move_worker_bin", "client_id:cloud_docs", "op:gid_create_read_id", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:filesystem.fs_job_worker_fs_job_worker-backfill_bin", "client_id:taskrunner_prod", "op:read_ep", "op:read_revision", "traffic:batch_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:blackbird_prod_high-memory", "op:prepare_xtxn", "op:read_revision", "traffic:live_traffic"},
+	{"source:fsverifier_fsverifier_worker_prod-fsverifier_worker_bin", "client_id:sprinkle", "op:read_ep", "op:read_revision", "traffic:live_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:filesystem", "op:txn", "op:txn", "traffic:live_traffic"},
+	{"source:metaserver_client_control-paster", "client_id:argus", "op:gid_create_read_id", "op:read_revision", "traffic:live_traffic"},
+	{"source:fs_move_worker_sjc.prod-fs_move_worker_bin", "client_id:sprinkle", "op:gid_create_read_id", "op:prepare_xtxn", "traffic:live_traffic"},
+	{"source:cape_yss_workers_RemoveMemberOnFileObjMoveTopology_RemoveMemberOnFileObjMoveLambda-remove_member_on_file_obj_move.py", "client_id:cape_dispatcher", "op:read_gid2", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:atf.store_consumer_yss_store_consumer_prod-atf_store_consumer_bin", "client_id:dropbox", "op:prepare_xtxn", "op:read_revision", "traffic:batch_traffic"},
+	{"source:metaserver_client-paster", "client_id:argus", "op:prepare_xtxn", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:metaserver_courier_live_site_control-main.py", "client_id:search_indexer", "op:read_revision", "op:insert_revision", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_PhotoAndVideoCollectionsRefreshTopology_PhotoVideoCollectionsRefreshLambda-pv_collections_refresh.py", "client_id:argus", "op:read_xtxn_conflict", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:owner_filesystem_team-namespace_member_backedge_consistency_checker.py", "client_id:iam", "op:prepare_xtxn", "op:read_ep", "traffic:batch_traffic"},
+	{"source:blackbird_worker_prod_restorations_sjc-blackbird_worker_bin", "client_id:cloud_docs", "op:read_gid2", "op:read_ep", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_canary_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda-async_task_worker_wrapper.py", "client_id:blackbird_prod_high-memory", "op:read_revision", "op:read_revision", "traffic:batch_traffic"},
+	{"source:filesystem.fs_job_worker_fs_job_worker-backfill_bin", "client_id:taskrunner_team_lifecycle", "op:read_xtxn_conflict", "op:read_ep", "traffic:batch_traffic"},
+	{"source:metaserver_courier_live_site_control-main.py", "client_id:taskrunner_prod", "op:read_xtxn_conflict", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:megaphone_megaphone_rpc_service_prod-megaphone_rpc_service.py", "client_id:dropbox", "op:prepare_xtxn", "op:gid_create_read_id", "traffic:live_traffic"},
+	{"source:metaserver_courier_live_site_control-main.py", "client_id:atf_store_consumer", "op:prepare_xtxn", "op:read_gid2", "traffic:batch_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:cape_dispatcher", "op:read_xtxn_conflict", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:cape_yss_workers_canary_asyncTaskWorkerWrapperTopology_asyncTaskWorkerWrapperLambda-async_task_worker_wrapper.py", "client_id:atf_controller", "op:prepare_xtxn", "op:prepare_xtxn", "traffic:batch_traffic"},
+	{"source:megaphone_megaphone_rpc_service_prod-megaphone_rpc_service.py", "client_id:team_lifecycle", "op:read_gid2", "op:prepare_xtxn", "traffic:live_traffic"},
+	{"source:metaserver_client-paster", "client_id:atf_store_consumer", "op:read_xtxn_conflict", "op:read_ep", "traffic:batch_traffic"},
+	{"source:owner_shared_spaces-count_shmodels_banned_under_rl_migration.py", "client_id:taskrunner_sharing_platform", "op:read_ep", "op:read_revision", "traffic:live_traffic"},
+	{"source:sync_frontend_sjc.canary-sync_frontend_server_bin", "client_id:atf_store_consumer", "op:read_gid2", "op:prepare_xtxn", "traffic:live_traffic"},
+	{"source:owner_messaging_team-delphi_store_consumer_bin", "client_id:blackbird_prod_alki-qa-streamer", "op:insert_revision", "op:read_xtxn_conflict", "traffic:batch_traffic"},
+	{"source:metaserver_client-paster", "client_id:audit_log", "op:insert_revision", "op:read_revision", "traffic:batch_traffic"},
+	{"source:owner_filesystem_team-namespace_member_backedge_consistency_checker.py", "client_id:taskrunner_prod", "op:read_xtxn_conflict", "op:gid_create_read_id", "traffic:batch_traffic"},
+	{"source:metaserver_client_canary-paster", "client_id:cloud_docs", "op:gid_create_read_id", "op:txn", "traffic:live_traffic"},
+}
+
+func BenchmarkProdDataSetWithRelease(b *testing.B) {
+	benchmarkSC := NewScorecard(benchmarkRules)
+	for i := 0; i < b.N; i++ {
+		for _, r := range requests {
+			trackingInfo := benchmarkSC.TrackRequest(r)
+			go func(ti *TrackingInfo) {
+				time.Sleep(1 * time.Millisecond)
+				ti.Untrack()
+			}(trackingInfo)
+		}
+	}
+}
+
+func BenchmarkProdDataSetWithoutRelease(b *testing.B) {
+	benchmarkSC := NewScorecard(benchmarkRules)
+	for i := 0; i < b.N; i++ {
+		for _, r := range requests {
+			benchmarkSC.TrackRequest(r)
+		}
+	}
 }

--- a/scorecard/scorecard_impl.go
+++ b/scorecard/scorecard_impl.go
@@ -80,7 +80,7 @@ func (r *Rule) isDefaultValue() bool {
 
 func ruleFor(rules []Rule, tag Tag) Rule {
 	for _, rule := range rules {
-		if TagMatchesRule(tag, rule) {
+		if FastMatch(tag, rule.Pattern) {
 			return rule
 		}
 	}


### PR DESCRIPTION
…rformance

path.scanChunk is one of hotter functions that shows up in our CPU profiles. path.scanChunk is called by path.Match() which is used by our Scorecard library to perform glob matching. Below is a cpu profile from one of the engines:

```
  flat  flat%   sum%        cum   cum%
11.17s 15.03% 15.03%     11.35s 15.28%  syscall.Syscall
 9.27s 12.48% 27.51%      9.50s 12.79%  runtime.cgocall
 3.13s  4.21% 31.72%      3.13s  4.21%  path.scanChunk 
 1.69s  2.27% 34.00%      8.35s 11.24%  runtime.mallocgc
 1.67s  2.25% 36.24%      1.67s  2.25%  runtime.memclrNoHeapPointers
 1.35s  1.82% 38.06%      1.35s  1.82%  runtime.futex
 1.22s  1.64% 39.70%      1.39s  1.87%  runtime.step
 1.15s  1.55% 41.25%      2.46s  3.31%  runtime.heapBitsSetType
 1.07s  1.44% 42.69%      1.07s  1.44%  runtime.memmove
 1.05s  1.41% 44.10%      1.05s  1.41%  runtime.nextFreeFast
```
Our match() implementation doesn't have to be complicated and only needs to handle the following two cases:

No special characters in the string or pattern -> This is essentially simply looping over the two strings and making sure they are the same
We can have a wildcard only as the last character in the pattern -> This is essentially same as above until the last but one and special cased to check for a wildcard.
Adding a custom implementation for this seems to perform better on existing benchmarks and the two benchmarks added as part of this diff. The two new benchmarks have the tags taken from scorecard dumps in prod against the current set of rules in prod.

Benchmark results with the custom match() function:

```
BenchmarkScorecard-4                     1000000              2128 ns/op
BenchmarkScorecardGenerate-4               30000             54276 ns/op
BenchmarkProdDataSetWithRelease-4           2000           1072412 ns/op
BenchmarkProdDataSetWithoutRelease-4        2000            696912 ns/op
```
Benchmark results with the existing path.Match():

```
BenchmarkScorecard-4                      500000              2597 ns/op
BenchmarkScorecardGenerate-4               20000             77005 ns/op
BenchmarkProdDataSetWithRelease-4           1000           1692555 ns/op
BenchmarkProdDataSetWithoutRelease-4        2000           1128893 ns/op
```