### PR TITLE
scorecard optimization rollback

### DIFF
--- a/scorecard/rule_parsing.go
+++ b/scorecard/rule_parsing.go
@@ -81,8 +81,8 @@ func (r Rule) Matches(t Tag) bool {
 // that fully matches a given set of tags. This is used to expand
 // a compound rule with glob patterns into multiple permutated variants.
 type compoundTagGenerator struct {
-	fragments           map[string][]fragmentPointer
-	orderedFragments    []*fragmentedRule
+	fragments        map[string][]fragmentPointer
+	orderedFragments []*fragmentedRule
 }
 
 // This holds the fragments derived from the given rule
@@ -233,12 +233,10 @@ func (ctg *compoundTagGenerator) combine(tags []Tag) []Tag {
 	product := make([]Tag, 0)
 	for _, fr := range ctg.orderedFragments {
 		if match, ok := matches[fr]; ok {
-			for _, permutation := range match.generate() {
-				// NOTE(opaugam) - for each permutation output a) the rule it
-				// belongs to (e.g the current ordered fragment pointer) and b)
-				// the permutation itself.
-				product = append(product, permutation)
-			}
+			// NOTE(opaugam) - for each permutation output a) the rule it
+			// belongs to (e.g the current ordered fragment pointer) and b)
+			// the permutation itself.
+			product = append(product, match.generate()...)
 		}
 	}
 

--- a/scorecard/rule_parsing_test.go
+++ b/scorecard/rule_parsing_test.go
@@ -170,49 +170,49 @@ func SameTags(a []Tag, b []Tag) bool {
 
 func (s *RuleParsingSuite) TestCompoundGenerateSimple() {
 	ctg := newCompoundTagGenerator([]Rule{{"op:read;gid:42", 5}})
-	_, tags := ctg.combine([]Tag{"op:read"})
+	tags := ctg.combine([]Tag{"op:read"})
 	assert.True(s.T(), SameTags(tags, []Tag{}))
-	_, tags = ctg.combine([]Tag{"op:read", "gid:*"})
+	tags = ctg.combine([]Tag{"op:read", "gid:*"})
 	assert.True(s.T(), SameTags(tags, []Tag{}))
-	_, tags = ctg.combine([]Tag{"op:read", "gid:13"})
+	tags = ctg.combine([]Tag{"op:read", "gid:13"})
 	assert.True(s.T(), SameTags(tags, []Tag{}))
-	_, tags = ctg.combine([]Tag{"op:read", "gid:42"})
+	tags = ctg.combine([]Tag{"op:read", "gid:42"})
 	assert.True(s.T(), SameTags(tags, []Tag{"op:read;gid:42"}))
 }
 
 func (s *RuleParsingSuite) TestCompoundGenerateNontrivial() {
 	ctg := newCompoundTagGenerator([]Rule{{"op:read", 2}})
-	_, tags := ctg.combine([]Tag{"op:read"})
+	tags := ctg.combine([]Tag{"op:read"})
 	assert.True(s.T(), SameTags(tags, []Tag{}))
 }
 
 func (s *RuleParsingSuite) TestWildcard() {
 	ctg := newCompoundTagGenerator([]Rule{{"op:*;gid:*", 5}})
-	_, tags := ctg.combine([]Tag{"op:read"})
+	tags := ctg.combine([]Tag{"op:read"})
 	assert.True(s.T(), SameTags(tags, []Tag{}))
-	_, tags = ctg.combine([]Tag{"op:read", "gid:*"})
+	tags = ctg.combine([]Tag{"op:read", "gid:*"})
 	assert.True(s.T(), SameTags(tags, []Tag{"op:read;gid:*"}))
-	_, tags = ctg.combine([]Tag{"op:read", "gid:42"})
+	tags = ctg.combine([]Tag{"op:read", "gid:42"})
 	assert.True(s.T(), SameTags(tags, []Tag{"op:read;gid:42"}))
-	_, tags = ctg.combine([]Tag{"gid:42", "op:read"})
+	tags = ctg.combine([]Tag{"gid:42", "op:read"})
 	assert.True(s.T(), SameTags(tags, []Tag{"op:read;gid:42"}))
 }
 
 func (s *RuleParsingSuite) TestRuleDupes() {
 	ctg := newCompoundTagGenerator([]Rule{{"op:*;gid:*", 5}, {"gid:*;op:*", 5}})
-	_, tags := ctg.combine([]Tag{"op:read"})
+	tags := ctg.combine([]Tag{"op:read"})
 	assert.True(s.T(), SameTags(tags, []Tag{}))
-	_, tags = ctg.combine([]Tag{"op:read", "gid:*"})
+	tags = ctg.combine([]Tag{"op:read", "gid:*"})
 	assert.True(s.T(), SameTags(tags, []Tag{"op:read;gid:*", "gid:*;op:read"}))
-	_, tags = ctg.combine([]Tag{"op:read", "gid:42"})
+	tags = ctg.combine([]Tag{"op:read", "gid:42"})
 	assert.True(s.T(), SameTags(tags, []Tag{"op:read;gid:42", "gid:42;op:read"}))
-	_, tags = ctg.combine([]Tag{"gid:42", "op:read"})
+	tags = ctg.combine([]Tag{"gid:42", "op:read"})
 	assert.True(s.T(), SameTags(tags, []Tag{"op:read;gid:42", "gid:42;op:read"}))
 }
 
 func (s *RuleParsingSuite) TestTagDupes() {
 	ctg := newCompoundTagGenerator([]Rule{{"op:*;gid:*", 5}})
-	_, tags := ctg.combine([]Tag{"op:read", "op:write", "op:list", "gid:42", "gid:13"})
+	tags := ctg.combine([]Tag{"op:read", "op:write", "op:list", "gid:42", "gid:13"})
 	out := []Tag{
 		"op:read;gid:42",
 		"op:read;gid:13",

--- a/scorecard/scorecard_impl.go
+++ b/scorecard/scorecard_impl.go
@@ -98,7 +98,6 @@ func (s *scorecardImpl) TrackRequest(tags []Tag) *TrackingInfo {
 	expanded = append(expanded, tags...)
 	for idx, tag := range expanded {
 		rule = ruleFor(rules, tag)
-	
 		if s.shouldIsolateTag(tag, rule) {
 			// shouldIsolate tracks rules in the scorecard. For now, it only tracks when the rule
 			// isn't violated (i.e. doesn't hit this branch). That means we will want to untrack the

--- a/scorecard/scorecard_test.go
+++ b/scorecard/scorecard_test.go
@@ -190,6 +190,26 @@ func (s *ScorecardSuite) TestRepeatedUntrack() {
 	require.Equal(s.T(), vals[Tag("GID_20")], uint(1))
 }
 
+func (s *ScorecardSuite) TestRegex() {
+	var benchmarkRules = []Rule{
+		{"traffic:live_traffic;source:metaserver*", 400},
+		{"traffic:live_traffic;source:*", 50},
+	}
+	bc := NewScorecard(benchmarkRules)
+	request := []Tag{
+		"client_id:meta",
+		"source:metaserver_courier_live_site-main.py",
+		"traffic:live_traffic",
+		"rpc_op:ep_add_or_get_for_ke",
+		"datatype:PublicDomainSuffixEntity",
+		"op:read_xtxn_conflict",
+	}
+	for i := 0; i < 51; i++ {
+		info := bc.TrackRequest(request)
+		require.Truef(s.T(), info.Tracked, "Violated: %s", info.Violated)
+	}
+}
+
 // Test that an isolated request does not alter the scorecard state
 func (s *ScorecardSuite) TestIsolatedRequest() {
 	// Setup


### PR DESCRIPTION
Removed the previously introduced optimization supposed to bypass globbing + making sure to not use the fast match helper when matching compound tags.