### PR TITLE
Use regex for rule matching

### DIFF
--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -19,6 +19,7 @@ package scorecard
 
 import (
 	"fmt"
+	"regexp"
 )
 
 // A Tag captures a single attribute of a request.
@@ -44,6 +45,11 @@ func NoTags() []Tag {
 type Rule struct {
 	Pattern  string
 	Capacity uint
+}
+
+type fastMatchRule struct {
+	Rule
+	regex *regexp.Regexp
 }
 
 func (r *Rule) String() string {


### PR DESCRIPTION
Updated scorecard implementation to compile a regex expression when a new scorecard is initialized. This expression is used to perform the matching of rules with tags as opposed to glob matching via path.Match()

**Benchmark results without regex**
```
BenchmarkScorecard-4                      500000              2539 ns/op
BenchmarkScorecardGenerate-4               30000             47088 ns/op
BenchmarkProdDataSetWithRelease-4           1000           2118143 ns/op
BenchmarkProdDataSetWithoutRelease-4        1000           1201993 ns/op
```
**Benchmark results with regex:**
```
BenchmarkScorecard-4                   	  500000	      3462 ns/op
BenchmarkScorecardGenerate-4           	   30000	     47166 ns/op
BenchmarkProdDataSetWithRelease-4      	    1000	   1504129 ns/op
BenchmarkProdDataSetWithoutRelease-4   	    2000	    903693 ns/op
```