### PR TITLE
Use custom comparison for rule matching

### DIFF
--- a/scorecard/scorecard.go
+++ b/scorecard/scorecard.go
@@ -19,7 +19,6 @@ package scorecard
 
 import (
 	"fmt"
-	"regexp"
 )
 
 // A Tag captures a single attribute of a request.
@@ -39,17 +38,20 @@ func NoTags() []Tag {
 // pattern that are permitted in the system before subsequent requests become
 // isolated.
 //
-// The pattern specified by the rule set uses common shell syntax as supported
-// by Go's path.Match function.  If the rule does not parse according to these
-// conventions, it will be treated as an exact string match only.
+// Patterns comprise of one or more fragments. Each fragment is separated by a delimiter (';')
+// For eg: If you consider the pattern: op:*;source:file_system then it has two fragments
+// op:* and source:file_system.
+// Individual fragments can be matched in one of the two ways
+// 1. Match as a literal
+// 2. Match the prefix of the pattern as a literal till we hit '*'. Once we hit the wild card
+//    we will match everything till the end of the fragment.
+// Iff all the fragments within a pattern match will we say that the pattern itself matches the request.
+//
+// Note: Fragments can only have a wild card as the last character and will not work with wild cards in the middle
+// TODO: Add validation for rules before we instantiate a new scorecard
 type Rule struct {
 	Pattern  string
 	Capacity uint
-}
-
-type fastMatchRule struct {
-	Rule
-	regex *regexp.Regexp
 }
 
 func (r *Rule) String() string {

--- a/scorecard/scorecard_impl.go
+++ b/scorecard/scorecard_impl.go
@@ -18,39 +18,19 @@ package scorecard
 
 import (
 	"hash/fnv"
-	"regexp"
-	"strings"
 	"sync"
 )
 
 // Implementation of the interfaces in scorecard.go.
 
-const (
-	numBuckets = 16 // Picked arbitrarily. Ideally should be tuned.
-
-	// Rule patterns have wild cards (*). We use regex matching to have better
-	// performance and the below string is used to replace the wild card pattern in
-	// the rule while performing regex compilation.
-	//
-	// Note: We use * at the end instead of + because in certain cases it's possible due to bugs
-	// that we don't emit a value for a tag but we'd still like it to match with the existing rules.
-	// Eg: Rule: op:*;source:foo will be compiled using ->  regexp.Compile("^op:[a-z|A-Z|0-9|_|-]*;source:foo$")
-	// This will match the tag: op:;source:foo" whereas if we had used a + it wouldn't match op:;source:foo.
-	//
-	// Note: We can't blindly replace * in the rule with .* because it'll end up matching more than we desire.
-	// For eg if we replace * with .* in the regex then the rule: op:*;source:* will have the regex: op:.*;source:.*
-	// This will end up matching tags that look like: op:read_gid2;rpc:read;source:file_system. We don't want
-	// the regex to match this because it has an additional tag, value pair namely rpc:read in the middle.
-	// Instead we simply match everything that's not a rule delimeter a.k.a ";"
-	starExpand = "[^;]*"
-)
+const numBuckets = 16 // Picked arbitrarily. Ideally should be tuned.
 
 type scorecardImpl struct {
 	// rulesMu protects rules and ctg.
 	// Those are pointers and fast to read and write, but under heavy concurrency
 	// contention becomes a problem, therefore RWMutex.
 	rulesMu sync.RWMutex
-	rules   []*fastMatchRule
+	rules   []Rule
 	ctg     *compoundTagGenerator
 
 	// To reduce lock contention, every `Tag` is mapped to one of `numBuckets` buckets which has
@@ -58,22 +38,14 @@ type scorecardImpl struct {
 	tagScoresBuckets [numBuckets]*tagScores
 }
 
-func getFastMatchRuleFromRule(rule Rule) *fastMatchRule {
-	ruleRegex, err := regexp.Compile("^" + strings.Replace(rule.Pattern, "*", starExpand, -1) + "$")
-	if err != nil {
-		panic(err)
-	}
-	return &fastMatchRule{Rule: rule, regex: ruleRegex}
-}
-
-func getRulesAndTagGenerator(rules []Rule) ([]*fastMatchRule, *compoundTagGenerator) {
+func getRulesAndTagGenerator(rules []Rule) ([]Rule, *compoundTagGenerator) {
 	// Dedup the rules
-	dedupedRules := make([]*fastMatchRule, 0, len(rules))
+	dedupedRules := make([]Rule, 0, len(rules))
 	ruleMap := make(map[string]struct{}, len(rules))
 	for _, rule := range rules {
 		// Add the rule if we have not seen it before
 		if _, ok := ruleMap[rule.Pattern]; !ok {
-			dedupedRules = append(dedupedRules, getFastMatchRuleFromRule(rule))
+			dedupedRules = append(dedupedRules, rule)
 			ruleMap[rule.Pattern] = struct{}{}
 		}
 	}
@@ -82,13 +54,13 @@ func getRulesAndTagGenerator(rules []Rule) ([]*fastMatchRule, *compoundTagGenera
 }
 
 func newScorecard(rules []Rule) Scorecard {
-	rule, ctg := getRulesAndTagGenerator(rules)
+	rules, ctg := getRulesAndTagGenerator(rules)
 	var tagScoresBuckets [numBuckets]*tagScores
 	for i := range tagScoresBuckets {
 		tagScoresBuckets[i] = &tagScores{tagToScore: make(map[Tag]uint)}
 	}
 	return &scorecardImpl{
-		rules:            rule,
+		rules:            rules,
 		ctg:              ctg,
 		tagScoresBuckets: tagScoresBuckets,
 	}
@@ -98,9 +70,7 @@ func (s *scorecardImpl) Rules() []Rule {
 	s.rulesMu.RLock()
 	defer s.rulesMu.RUnlock()
 	rules := make([]Rule, len(s.rules))
-	for idx, rule := range s.rules {
-		rules[idx] = rule.Rule
-	}
+	copy(rules, s.rules)
 	return rules
 }
 
@@ -108,10 +78,10 @@ func (r *Rule) isDefaultValue() bool {
 	return r.Pattern == "" && r.Capacity == 0
 }
 
-func ruleFor(rules []*fastMatchRule, tag Tag) Rule {
+func ruleFor(rules []Rule, tag Tag) Rule {
 	for _, rule := range rules {
-		if FastMatchCompoundRule(tag, rule) {
-			return rule.Rule
+		if TagMatchesRule(tag, rule) {
+			return rule
 		}
 	}
 	return Rule{}
@@ -152,9 +122,9 @@ func (s *scorecardImpl) TrackRequest(tags []Tag) *TrackingInfo {
 }
 
 func (s *scorecardImpl) Reconfigure(rules []Rule) {
-	rulesForFastMatching, ctg := getRulesAndTagGenerator(rules)
+	rules, ctg := getRulesAndTagGenerator(rules)
 	s.rulesMu.Lock()
-	s.rules = rulesForFastMatching
+	s.rules = rules
 	s.ctg = ctg
 	s.rulesMu.Unlock()
 }


### PR DESCRIPTION
Updated scorecard implementation to compile a regex expression when a new scorecard is initialized. This expression is used to perform the matching of rules with tags as opposed to glob matching via path.Match()

**Benchmark results with existing match**
```
BenchmarkScorecard-4                      500000              2539 ns/op
BenchmarkScorecardGenerate-4               30000             47088 ns/op
BenchmarkProdDataSetWithRelease-4           1000           2118143 ns/op
BenchmarkProdDataSetWithoutRelease-4        1000           1201993 ns/op
```

**Benchmark results with custom match:** 
```
BenchmarkScorecard-4                     1000000              2107 ns/op
BenchmarkScorecardGenerate-4               30000             48146 ns/op
BenchmarkProdDataSetWithRelease-4           2000           1190656 ns/op
BenchmarkProdDataSetWithoutRelease-4        2000            758932 ns/op
```