### PR TITLE
Reduce allocations in scorecard_impl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-    - "1.10.x"
-    - "1.11.x"
+    - "1.13.x"
 
 before_script:
     - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH) v1.12.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
     - "1.13.x"
 
 before_script:
-    - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH) v1.12.3
+    - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH) v1.30.0
 
 script:
     - $(go env GOPATH)/golangci-lint run

--- a/scorecard/rule_parsing.go
+++ b/scorecard/rule_parsing.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scorecard
 
 import (
-	"bytes"
 	"strings"
 )
 
@@ -148,7 +147,7 @@ func (ms *matchState) generate() []Tag {
 	// calculation
 	indices := make([]int, len(ms.matches))
 	tags := make([]Tag, 0, productSize(ms.matches))
-	var buf bytes.Buffer
+	var buf strings.Builder
 	for !ms.permutationDone(indices) {
 		for i := 0; i < len(ms.matches); i++ {
 			if i > 0 {

--- a/scorecard/scorecard_bench_test.go
+++ b/scorecard/scorecard_bench_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func BenchmarkScorecard(b *testing.B) {
+	b.ReportAllocs()
 	b.SetParallelism(16)
 	rules := [][]Rule{
 		{{"op:*;cat:*", 5}, {"cat:*", 5}, {"dog:*", 5}},
@@ -44,6 +45,7 @@ func BenchmarkScorecard(b *testing.B) {
 // BenchmarkScorecardGenerate exercises a realistic case where there are many
 // tags matching a rule fragment and the production of AxB is costly.
 func BenchmarkScorecardGenerate(b *testing.B) {
+	b.ReportAllocs()
 	sc := NewDynamicScorecard([]Rule{{"op:*;dog:*", 1}, {"op:*;cat:*", 5}, {"cat:*", 5}, {"dog:*", 5}})
 	tags := []Tag{
 		Tag("op:cat_create_txn"),
@@ -422,7 +424,17 @@ var requests = [][]Tag{
 	{"source:metaserver_client_canary-paster", "client_id:cloud_docs", "op:gid_create_read_id", "op:txn", "traffic:live_traffic"},
 }
 
+func BenchmarkBucket(b *testing.B) {
+	b.ReportAllocs()
+	sc := NewDynamicScorecard([]Rule{{"op:*;dog:*", 1}, {"op:*;cat:*", 5}, {"cat:*", 5}, {"dog:*", 5}})
+	tag := Tag("op:cat_create_txn")
+	for i := 0; i < b.N; i++ {
+		_ = sc.(*scorecardImpl).bucket(tag)
+	}
+}
+
 func BenchmarkProdDataSetWithRelease(b *testing.B) {
+	b.ReportAllocs()
 	benchmarkSC := NewScorecard(benchmarkRules)
 	for i := 0; i < b.N; i++ {
 		for _, r := range requests {
@@ -436,6 +448,7 @@ func BenchmarkProdDataSetWithRelease(b *testing.B) {
 }
 
 func BenchmarkProdDataSetWithoutRelease(b *testing.B) {
+	b.ReportAllocs()
 	benchmarkSC := NewScorecard(benchmarkRules)
 	for i := 0; i < b.N; i++ {
 		for _, r := range requests {

--- a/scorecard/scorecard_impl.go
+++ b/scorecard/scorecard_impl.go
@@ -150,7 +150,7 @@ func (s *scorecardImpl) bucket(tag Tag) *tagScores {
 	return s.tagScoresBuckets[hash(tag)%numBuckets]
 }
 
-// constants lifted from fnv32a
+// constants lifted from fnv32a.
 const (
 	offset32 = 2166136261
 	prime32  = 16777619


### PR DESCRIPTION
In a large go program using load_management (a mysql proxy) I saw that scorecard.bucket accounts for over 5% of allocated objects in and accounts for over 1% of the cpu:

alloc_objects:
```
Total:     4773904    5822496 (flat, cum)  5.86%
  147            .          .           	s.bucket(tag).removeReference(tag) 
  148            .          .           } 
  149            .          .            
  150            .          .           func (s *scorecardImpl) bucket(tag Tag) *tagScores { 
  151            .          .           	// This hash was picked arbitrarily. The fastest, crudest, hash is probably ideal. 
  152            .    1048592           	h := fnv.New32a() 
  153      4773904    4773904           	_, _ = h.Write([]byte(tag)) 
  154            .          .           	return s.tagScoresBuckets[h.Sum32()%numBuckets]
```
cpu:
```
Total:        80ms      660ms (flat, cum)  1.23%
  147            .          .           	s.bucket(tag).removeReference(tag) 
  148            .          .           } 
  149            .          .            
  150            .          .           func (s *scorecardImpl) bucket(tag Tag) *tagScores { 
  151            .          .           	// This hash was picked arbitrarily. The fastest, crudest, hash is probably ideal. 
  152            .      110ms           	h := fnv.New32a() 
  153         40ms      480ms           	_, _ = h.Write([]byte(tag)) 
  154         40ms       70ms           	return s.tagScoresBuckets[h.Sum32()%numBuckets]
```
A lot of that cost comes from the fact that creating a byte-slice from a Tag escapes from the heap, but we need to create one in order to write to the Hash (which also escapes). I played around with it and couldn't come up with a way to avoid the allocation without using unsafe.Pointer. Ultimately, I came to this approach which basically lifts the fnv32a Write implementation and applies it directly to a Tag.

I also swapped the bytes.Buffer in the matchState for a strings.Builder to save the alloc when String-ing it.

Results look pretty decent:
```
benchmark                                old ns/op     new ns/op     delta
BenchmarkScorecard-4                     2889          2649          -8.31%
BenchmarkScorecardGenerate-4             71201         65820         -7.56%
BenchmarkBucket-4                        114           29.4          -74.21%
BenchmarkProdDataSetWithRelease-4        1466492       1353710       -7.69%
BenchmarkProdDataSetWithoutRelease-4     1071584       995530        -7.10%

benchmark                                old allocs     new allocs     delta
BenchmarkScorecard-4                     24             13             -45.83%
BenchmarkScorecardGenerate-4             276            273            -1.09%
BenchmarkBucket-4                        2              0              -100.00%
BenchmarkProdDataSetWithRelease-4        7322           5110           -30.21%
BenchmarkProdDataSetWithoutRelease-4     5739           5010           -12.70%

benchmark                                old bytes     new bytes     delta
BenchmarkScorecard-4                     556           428           -23.02%
BenchmarkScorecardGenerate-4             33047         32946         -0.31%
BenchmarkBucket-4                        36            0             -100.00%
BenchmarkProdDataSetWithRelease-4        247520        188592        -23.81%
BenchmarkProdDataSetWithoutRelease-4     207509        182176        -12.21%
```